### PR TITLE
Add detailed page about organizer roles; update index with it

### DIFF
--- a/docs/confs/organizers.rst
+++ b/docs/confs/organizers.rst
@@ -1,0 +1,19 @@
+.. conf_organizers:
+
+Roles and Responsibilities for Organizers
+=========================================
+
+The main organizer team historically includes the following roles, with brief descriptions of their responsibilities:
+
+* Lead on the ground; should be someone local to the city where the conference is held. This role wrangles all the wrangling, and coordinates with design, swag and sign ordering, and more. (Historically this has been Eric everywhere, but as we grow we're trying to distribute this role more.)
+* Communications liaison. This work is shared with others (notably for volunteer and speaker communication). Other responsibilities for the role include any emails to the larger community: announcing registration and CFP, reminders and updates, welcome information, day-of announcements, thanks for coming, reminders about next/other conferences and events. Should probably also include systematic twitter monitoring and posting (although this is also somewhat shared)
+* Volunteer coordinator. Recruits volunteers, keeps communication going, maintains shift lists, serves as volunteer point person and backup during conference.
+* Speaker wrangler. Responsible for emails with accepted speakers before conference, making sure speakers are cued up before their talks, providing for any special needs. Historically has also wrangled speaker gifts, but this should probably be handed off to someone else.
+* Unconf wrangler. Set up board for unconf signups (Google sheet is also available as template). Keep an eye on any unconf sessions. Pretty lightweight responsibilities.
+* Sponsorship lead (currently Adrienne, not an event-specific role)
+
+Other Important Roles to Remember
+=================================
+
+* Proposal reviewers. In 2016 this group was expanded to include folks who weren't otherwise organizers, and the process was streamlined. It's still time-consuming and intense, because we try to decide pretty quickly after the CFP closes.
+* Emcee. Historically this person hasn't necessarily been one of the main organizers. Must be someone personable, with good voice and stage presence, but also good at keeping things brief, getting out of the way, and helping troubleshoot speaker issues as needed.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -11,6 +11,7 @@ This guide covers the following types of Write the Docs events:
    
    confs/checklist
    confs/orgteam
+   confs/organizers
    confs/budget
    confs/venues-logistics
    confs/sponsorship


### PR DESCRIPTION
For linking from letter to east coast organizers; also generally useful and currently missing.
